### PR TITLE
Make indentation fixing robust

### DIFF
--- a/cmd/fix.go
+++ b/cmd/fix.go
@@ -124,17 +124,22 @@ var fixCmd = &cobra.Command{
 			encoder.SetIndent(indentationLevel)
 			err = encoder.Encode(fileNode.Node)
 			if err != nil {
-				log.Printf("File '%s' has encode errors:\n%v", filePath, err)
+				log.Printf("File '%s' has encode errors:\n%v\n", filePath, err)
 				continue
 			}
 			fileStat, err := os.Stat(filePath)
 			if err != nil {
-				log.Fatal(err)
+				log.Println(err)
 				continue
 			}
 			fileContents := buf.Bytes()
 			if reduceIndentationBy != 0 {
-				fileContents = indentation.FixLists(fileContents, reduceIndentationBy)
+				var err error
+				fileContents, err = indentation.FixLists(fileNode, fileContents, reduceIndentationBy)
+				if err != nil {
+					log.Println(err)
+					continue
+				}
 			}
 
 			// check if contents changed

--- a/pkg/indentation/indentation.go
+++ b/pkg/indentation/indentation.go
@@ -1,20 +1,37 @@
+/*
+Copyright © 2022 david amick git@davidamick.com
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package indentation
 
 import (
 	"bufio"
 	"bytes"
-	"log"
 	"regexp"
+
+	"github.com/snarlysodboxer/predictable-yaml/pkg/compare"
+	"gopkg.in/yaml.v3"
 )
 
 type startStop struct {
-	start  int
-	stop   int
-	spaces int
+	start     int
+	stop      int
+	goesToEnd bool
 }
 
 // FixLists can unindent lists in yaml. Expects consistent input indentation.
-func FixLists(content []byte, reduceBy int) []byte {
+func FixLists(node *compare.Node, content []byte, reduceBy int) ([]byte, error) {
 	// create a slice of lines
 	lines := []string{}
 	scanner := bufio.NewScanner(bytes.NewReader(content))
@@ -22,75 +39,100 @@ func FixLists(content []byte, reduceBy int) []byte {
 		lines = append(lines, scanner.Text())
 	}
 	if err := scanner.Err(); err != nil {
-		log.Fatal(err)
+		return []byte{}, err
 	}
 
-	// find lines starting with `- `, and the following line that ends that value
-	sequences := []startStop{}
-	sequenceStart := regexp.MustCompile(`^\s*- `)
-	leadSpaces := regexp.MustCompile(`^\s*`)
+	sequences := walkGetStartStopSequences(node, []*startStop{})
+
+	// convert to map
+	lineMap := map[int]string{}
+	for index, line := range lines {
+		lineMap[index] = line
+	}
+
+	// unindent those lines in the map by reduceBy spaces
 	fmtStr := "^"
 	for i := 1; i <= reduceBy; i++ {
 		fmtStr += " "
 	}
 	firstNSpaces := regexp.MustCompile(fmtStr)
-Lines:
-	for index, line := range lines {
-		if !sequenceStart.MatchString(line) {
+	for _, ss := range sequences {
+		if ss.goesToEnd {
+			for i := ss.start; i <= len(lineMap)-1; i++ {
+				lineMap[i] = string(firstNSpaces.ReplaceAll([]byte(lineMap[i]), []byte{}))
+			}
 			continue
 		}
-		ss := startStop{
-			start:  index,
-			spaces: len(leadSpaces.Find([]byte(line))),
-		}
-		// check if this is an instance of an existing sequence
-		for _, existingSS := range sequences {
-			if index > existingSS.start && index <= existingSS.stop && existingSS.spaces == ss.spaces {
-				continue Lines
-			}
-		}
-
-		for innerIndex, innerLine := range lines {
-			// start with the first line following sequence start
-			if innerIndex <= index {
-				continue
-			}
-			// if the number of spaces is lower, the sequence ended the line before
-			innerSpaces := len(leadSpaces.Find([]byte(innerLine)))
-			if innerSpaces < ss.spaces {
-				ss.stop = innerIndex - 1
-				// defense
-				if ss.stop < ss.start {
-					panic("something went wrong")
-				}
-				break
-			}
-		}
-		// if an end was not found, then the sequence goes to the end
-		if ss.stop == 0 && ss.start > 0 {
-			ss.stop = len(lines) - 1
-		}
-		sequences = append(sequences, ss)
-	}
-
-	// convert to map
-	newLines := map[int]string{}
-	for index, line := range lines {
-		newLines[index] = line
-	}
-
-	// unindent those lines in the map by reduceBy spaces
-	for _, ss := range sequences {
 		for i := ss.start; i <= ss.stop; i++ {
-			newLines[i] = string(firstNSpaces.ReplaceAll([]byte(newLines[i]), []byte{}))
+			lineMap[i] = string(firstNSpaces.ReplaceAll([]byte(lineMap[i]), []byte{}))
 		}
 	}
 
 	// reassemble
 	newContent := ""
-	for i := 0; i < len(newLines); i++ {
-		newContent += newLines[i] + "\n"
+	for i := 0; i < len(lineMap); i++ {
+		newContent += lineMap[i] + "\n"
 	}
 
-	return []byte(newContent)
+	return []byte(newContent), nil
+}
+
+func walkGetStartStopSequences(n *compare.Node, sequences []*startStop) []*startStop {
+	// work against n's NodeContent
+	end := len(n.NodeContent) - 1
+	for index, node := range n.NodeContent {
+		sequences = walkGetStartStopSequences(node, sequences)
+
+		// only work with kind Sequence
+		if node.Kind != yaml.SequenceNode {
+			continue
+		}
+		// don't manage indentation for FlowStyle (inline)
+		if node.Style == yaml.FlowStyle {
+			continue
+		}
+
+		ss := startStop{start: node.Line - 1}
+		switch {
+		case len(n.NodeContent) == 1:
+			// if the NodeContent length is only 1, then end is same as start
+			ss.stop = node.Line - 1
+		case index+1 <= end:
+			// if there is a node following this one in NodeContent slice, then
+			//   it's the line of that node minus 2
+			ss.stop = n.NodeContent[index+1].Line - 2
+		case index+1 > end:
+			// find parent or parent of parent with following sibling, if exists
+			parentStop, found := walkGetParentStop(node)
+			if found {
+				// is end of NodeContent but not end of file
+				ss.stop = parentStop
+			} else {
+				// is end of file
+				ss.goesToEnd = true
+			}
+		}
+		sequences = append(sequences, &ss)
+	}
+
+	return sequences
+}
+
+// find parent or parent of parent with following sibling, if exists
+func walkGetParentStop(n *compare.Node) (int, bool) {
+	if n.ParentNode == nil {
+		return 0, false
+	}
+
+	end := len(n.ParentNode.NodeContent) - 1
+	for index, node := range n.ParentNode.NodeContent {
+		if node == n {
+			if index+1 <= end {
+				return n.ParentNode.NodeContent[index+1].Line - 2, true
+			}
+			break
+		}
+	}
+
+	return walkGetParentStop(n.ParentNode)
 }


### PR DESCRIPTION
Indentation reduction was done by regex before. This switches to using the yaml v3 library to determine what lines should be reduced in indentation.