### PR TITLE
Make indentation-fixer more standalone, fix bug

### DIFF
--- a/cmd/fix.go
+++ b/cmd/fix.go
@@ -127,15 +127,10 @@ var fixCmd = &cobra.Command{
 				log.Printf("File '%s' has encode errors:\n%v\n", filePath, err)
 				continue
 			}
-			fileStat, err := os.Stat(filePath)
-			if err != nil {
-				log.Println(err)
-				continue
-			}
 			fileContents := buf.Bytes()
 			if reduceIndentationBy != 0 {
 				var err error
-				fileContents, err = indentation.FixLists(fileNode, fileContents, reduceIndentationBy)
+				fileContents, err = indentation.FixLists(fileContents, reduceIndentationBy)
 				if err != nil {
 					log.Println(err)
 					continue
@@ -162,9 +157,14 @@ var fixCmd = &cobra.Command{
 				}
 
 				if doFix {
+					fileStat, err := os.Stat(filePath)
+					if err != nil {
+						log.Println(err)
+						continue
+					}
 					err = os.WriteFile(filePath, fileContents, fileStat.Mode())
 					if err != nil {
-						log.Printf("File '%s' has write errors:\n%v", filePath, err)
+						log.Printf("File '%s' has write errors:\n%v\n", filePath, err)
 						continue
 					}
 					log.Printf("File '%s' has been fixed!", filePath)

--- a/pkg/indentation/indentation.go
+++ b/pkg/indentation/indentation.go
@@ -31,7 +31,16 @@ type startStop struct {
 }
 
 // FixLists can unindent lists in yaml. Expects consistent input indentation.
-func FixLists(node *compare.Node, content []byte, reduceBy int) ([]byte, error) {
+func FixLists(content []byte, reduceBy int) ([]byte, error) {
+	// parse yaml
+	yamlNode := &yaml.Node{}
+	err := yaml.Unmarshal(content, yamlNode)
+	if err != nil {
+		return content, err
+	}
+	node := &compare.Node{Node: yamlNode}
+	compare.WalkConvertYamlNodeToMainNode(node)
+
 	// create a slice of lines
 	lines := []string{}
 	scanner := bufio.NewScanner(bytes.NewReader(content))
@@ -42,6 +51,7 @@ func FixLists(node *compare.Node, content []byte, reduceBy int) ([]byte, error) 
 		return []byte{}, err
 	}
 
+	// get the list of lines that start/stop sequences
 	sequences := walkGetStartStopSequences(node, []*startStop{})
 
 	// convert to map

--- a/pkg/indentation/indentation_test.go
+++ b/pkg/indentation/indentation_test.go
@@ -17,9 +17,6 @@ package indentation
 
 import (
 	"testing"
-
-	"github.com/snarlysodboxer/predictable-yaml/pkg/compare"
-	"gopkg.in/yaml.v3"
 )
 
 func TestFixLists(t *testing.T) {
@@ -267,15 +264,7 @@ spec:
 		},
 	}
 	for _, tc := range testCases {
-		yNode := &yaml.Node{}
-		err := yaml.Unmarshal([]byte(tc.yaml), yNode)
-		if err != nil {
-			t.Errorf("Description: %s: main.FixLists(...): \n-expected:\n%#v\n+got:\n%#v\n", tc.note, nil, err)
-			continue
-		}
-		fileNode := &compare.Node{Node: yNode}
-		compare.WalkConvertYamlNodeToMainNode(fileNode)
-		got, err := FixLists(fileNode, []byte(tc.yaml), tc.reduceBy)
+		got, err := FixLists([]byte(tc.yaml), tc.reduceBy)
 		if err != nil {
 			t.Errorf("Description: %s: main.FixLists(...): \n-expected:\n%#v\n+got:\n%#v\n", tc.note, nil, err)
 		}


### PR DESCRIPTION
The fixer was trying to re-use the `compare.Node` the fix functionality already has, but that version is not complete with proper line numbers, since it's be sorted. - So instead indentation-fixer should reparse the yaml and reconvert it to a `compare.Node`.

This has the benefit of making `indentation.FixLists` more reusable by other libraries.