### PR TITLE
Stop search for config dirs at root

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ This is alpha, but ready for use.
 ## Install
 Download the binary for your system and then move it in place
 ```shell
-mv ~/Downloads/preditable-yaml-darwin-amd64 /usr/local/bin/preditable-yaml
-chmod ug+x /usr/local/bin/preditable-yaml
+mv ~/Downloads/predictable-yaml-darwin-amd64 /usr/local/bin/predictable-yaml
+chmod ug+x /usr/local/bin/predictable-yaml
 # on MacOS
-sudo xattr -r -d com.apple.quarantine /usr/local/bin/preditable-yaml
+sudo xattr -r -d com.apple.quarantine /usr/local/bin/predictable-yaml
 ```
 OR just clone the repo and `go install`.
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -134,6 +134,10 @@ func walkFindConfigDirs(dir string, configDirs []string) ([]string, error) {
 		return configDirs, nil
 	}
 	parentDir := filepath.Dir(dir)
+	if parentDir == dir {
+		// reached root
+		return configDirs, nil
+	}
 	configDirs, err = walkFindConfigDirs(parentDir, configDirs)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Sometimes, like when running in CI, we're running in a dir that's not a subdir of home. Handle that.

Also fix typos in readme.