### PR TITLE
Support full config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ predictable-yaml lint my-k8s-manifests/
 predictable-yaml fix my-k8s-manifests/
 ```
 
-Out of the box, `predictable-yaml` knows how to lint and fix Deployments, Services, Pods, ConfigMaps, CronJobs, Ingresses, and [many more Kubernetes types](https://github.com/snarlysodboxer/predictable-yaml-configs). No configuration required.
+Out of the box, `predictable-yaml` ships with opinionated configs for linting and fixing Deployments, Services, Pods, ConfigMaps, CronJobs, Ingresses, and [many more Kubernetes types](https://github.com/snarlysodboxer/predictable-yaml-configs). No configuration is required, but you can bring your own configs/schemas if you prefer.
 
 ## Install
 
@@ -67,35 +67,72 @@ go install
 
 1. **`--config-dir` flag** - If specified, only configs from that directory are used.
 2. **Local `.predictable-yaml/` directories** - Searched up the directory tree from the working directory and down into target paths. Subdirectory configs override parent configs for files under that path.
-3. **Remote configs** - Fetched from a git repository specified in `.predictable-yaml/.remote`.
+3. **Remote configs** - Fetched from a git repository specified in `.predictable-yaml.yaml` (or the legacy `.predictable-yaml/.remote`).
 4. **Built-in defaults** - Kubernetes/Kustomize schemas embedded in the binary.
 
-For most Kubernetes projects, the built-in defaults work without any configuration. For custom schemas or to pin a specific config version, use remote configs.
+The built-in defaults will work without any configuration. You may want to pin a specific config version using a project config file, or even set up your own custom schemas.
 
-### Remote Configs
+### Project Config File
 
-Instead of maintaining `.predictable-yaml` config directories in every repo, point to a remote config repository. Create a `.predictable-yaml/.remote` file:
+Create a `.predictable-yaml.yaml` file in your project root to configure remote configs and fixer defaults:
 
 ```yaml
-# Uses the default config repo (github.com/snarlysodboxer/predictable-yaml-configs)
-version: v1.0.0
+# Pin a version of the default config repo
+remote:
+  version: v1.0.5
 ```
 
 ```yaml
-# Custom repo, pinned to a tag
-remote: https://github.com/my-org/my-yaml-configs
-version: v2.3.0
+# Custom repo, pinned to a tag, with fixer defaults
+# The `version` field accepts any git ref: a tag, commit SHA, or branch name.
+remote:
+  url: https://github.com/my-org/my-yaml-configs
+  version: v2.3.0
+fixer:
+  indentation-level: 4
+  compact-lists: false
 ```
 
-The `version` field accepts any git ref: a tag, commit SHA, or branch name.
+The file is searched up the directory tree from the working directory, similar to `.golangci.yml` or `.prettierrc`. The closest config file to the working directory wins.
 
-Configs are fetched once and cached locally in `.predictable-yaml/.cache/`. When the version is bumped in `.remote`, the cache is automatically updated on the next run.
+**Fields:**
+
+**Top-level fields:**
+
+| Field | Description |
+|-------|-------------|
+| `config-dir` | Directory containing schema config files |
+
+**`remote:` fields:**
+
+| Field | Description |
+|-------|-------------|
+| `url` | Git repository URL (defaults to [predictable-yaml-configs](https://github.com/snarlysodboxer/predictable-yaml-configs)) |
+| `version` | Git ref to fetch (tag, commit SHA, or branch name) |
+
+**`fixer:` fields** (all overridden by their corresponding CLI flag):
+
+| Field | Description |
+|-------|-------------|
+| `indentation-level` | YAML indentation spaces (default: 2) |
+| `compact-lists` | Make `- ` count as indentation (default: true) |
+| `add-preferred` | Add preferred keys when adding missing keys (default: false) |
+| `disable-post-processing` | Disable all post-processing (default: false) |
+| `prompt` | Show diff and prompt before making changes (default: true) |
+| `prompt-if-line-count-change` | Only prompt if line count changes (default: false) |
+| `unmatched-to-beginning` | Move unmatched keys to beginning instead of end (default: false) |
+| `validate` | Only sort if validation fails (default: true) |
+
+Configs are fetched once and cached locally in `.predictable-yaml/.cache/`. When the version is bumped, the cache is automatically updated on the next run.
 
 - `.predictable-yaml/.cache/` should be gitignored.
-- `.predictable-yaml/.remote` should be committed.
-- Local config files in `.predictable-yaml/` still override remote configs.
-- Nested `.remote` files in subdirectories work the same as nested local configs.
+- `.predictable-yaml.yaml` should be committed.
+- Local config files in `.predictable-yaml/` override remote configs.
 - GitHub, GitLab, and Bitbucket are supported. Private repos use `GITHUB_TOKEN`, `GITLAB_TOKEN`, or `BITBUCKET_TOKEN` env vars, falling back to local git credentials.
+
+### Legacy: `.predictable-yaml/.remote`
+
+The `.predictable-yaml/.remote` file is still supported for backward compatibility. If `.predictable-yaml.yaml` exists with `remote`/`version`, it takes precedence and a deprecation warning is logged if `.remote` also exists. To migrate, move `remote` and `version` from `.predictable-yaml/.remote` to `.predictable-yaml.yaml` and delete the `.remote` file.
 
 ### Show Active Configs
 
@@ -168,8 +205,8 @@ export PREDICTABLE_YAML_DIFF="difft"
 
 - **Key reordering** - Reorders keys to match the config schema. Always produces valid YAML.
 - **Structural summary** - Shows a YAML-like summary of what moved and what was added, with comment preservation status.
-- **Preserve empty lines** - Associates empty lines with the YAML key following them and reinserts them after reordering. Reinserts trailing empty lines if present in the original. *(enabled by default, disable with `--preserve-empty-lines=false`)*
-- **Preserve comments** - Replaces comment spacing with the original versions after reordering. *(enabled by default, disable with `--preserve-comments=false`)*
+- **Preserve empty lines** - Associates empty lines with the YAML key following them and reinserts them after reordering. Reinserts trailing empty lines if present in the original.
+- **Preserve comments** - Replaces comment spacing with the original versions after reordering.
 - **Compact lists** - Makes `- ` count as part of the indentation for list items, so `-` is even with the parent key instead of indented. *(enabled by default, disable with `--compact-lists=false`)*
 - **Add missing keys** - Adds required keys that are missing from the file. Preferred keys can also be added with `--add-preferred`.
 - **Unmatched key placement** - Keys in the file that aren't in the config are moved to the end of their map by default. Use `--unmatched-to-beginning` to move them to the start instead.
@@ -188,7 +225,7 @@ export PREDICTABLE_YAML_DIFF="difft"
 - Head comment indentation: yaml.v3 normalizes head comment indentation during parsing. The fixer restores original indentation in most cases by searching for comment text in surrounding nodes, but there may be edge cases where the comment gets re-indented to match the key's indentation level.
 
 **Empty line handling:**
-- Whitespace preservation is not perfect in every circumstance, as it involves inferring intent from empty lines. Disable with `--preserve-empty-lines=false` if results are unexpected.
+- Whitespace preservation is not perfect in every circumstance, as it involves inferring intent from empty lines. Disable with `-d` if results are unexpected.
 - Empty lines are associated with the YAML node on the line below them. When keys are reordered, the empty line moves with the key it was above. This is usually the desired behavior, but may occasionally produce unexpected results.
 - Multiple consecutive empty lines (2+) are preserved correctly.
 

--- a/cmd/fix.go
+++ b/cmd/fix.go
@@ -42,13 +42,10 @@ var (
 	prompt                  bool
 	promptIfLineCountChange bool
 	compactLists            bool
-	reduceIndentationBy     int // deprecated, mapped to compactLists
 	indentationLevel        int
 	unmatchedToBeginning    bool
 	addPreferreds           bool
 	validate                bool
-	preserveEmptyLines      bool
-	preserveComments        bool
 	disablePostProcessing   bool
 )
 
@@ -70,16 +67,7 @@ var fixCmd = &cobra.Command{
 		return nil
 	},
 	Run: func(cmd *cobra.Command, filePaths []string) {
-		// map deprecated --reduce-list-indentation-by to --compact-lists
-		if cmd.Flags().Changed("reduce-list-indentation-by") {
-			compactLists = reduceIndentationBy != 0
-		}
-
 		// setup
-		configDirFlag := ""
-		if cfgDir != "" {
-			configDirFlag = cfgDir
-		}
 		workDir, err := os.Getwd()
 		if err != nil {
 			log.Fatal(err)
@@ -92,7 +80,39 @@ var fixCmd = &cobra.Command{
 		if err != nil {
 			log.Fatal(err)
 		}
-		cfgNodesByPaths := getConfigNodesByPath(configDirFlag, workDir, homeDir, allFilePaths)
+
+		// Load project config and apply settings for flags not explicitly set
+		projectCfg, projectCfgDir := loadProjectConfig(workDir, homeDir)
+		configDirFlag := resolveConfigDir(projectCfg, projectCfgDir)
+		if projectCfg != nil {
+			f := projectCfg.Fixer
+			if f.IndentationLevel != nil && !cmd.Flags().Changed("indentation-level") {
+				indentationLevel = *f.IndentationLevel
+			}
+			if f.CompactLists != nil && !cmd.Flags().Changed("compact-lists") {
+				compactLists = *f.CompactLists
+			}
+			if f.AddPreferred != nil && !cmd.Flags().Changed("add-preferred") {
+				addPreferreds = *f.AddPreferred
+			}
+			if f.DisablePostProcessing != nil && !cmd.Flags().Changed("disable-post-processing") {
+				disablePostProcessing = *f.DisablePostProcessing
+			}
+			if f.Prompt != nil && !cmd.Flags().Changed("prompt") {
+				prompt = *f.Prompt
+			}
+			if f.PromptIfLineCountChange != nil && !cmd.Flags().Changed("prompt-if-line-count-change") {
+				promptIfLineCountChange = *f.PromptIfLineCountChange
+			}
+			if f.UnmatchedToBeginning != nil && !cmd.Flags().Changed("unmatched-to-beginning") {
+				unmatchedToBeginning = *f.UnmatchedToBeginning
+			}
+			if f.Validate != nil && !cmd.Flags().Changed("validate") {
+				validate = *f.Validate
+			}
+		}
+
+		cfgNodesByPaths := getConfigNodesByPath(configDirFlag, workDir, homeDir, allFilePaths, projectCfg, projectCfgDir)
 
 		success := true
 
@@ -143,7 +163,7 @@ var fixCmd = &cobra.Command{
 				log.Fatalf("error parsing yaml for target file: %s: %v", filePath, err)
 			}
 			commentCount := 0
-			if preserveComments && !disablePostProcessing {
+			if !disablePostProcessing {
 				commentCount = moves.CountComments(oldFileNode)
 			}
 
@@ -183,19 +203,15 @@ var fixCmd = &cobra.Command{
 			fileContents := buf.Bytes()
 
 			if !disablePostProcessing {
-				if preserveComments {
-					fileContents, err = whitespace.PreserveComments(existingFileContents, fileContents)
-					if err != nil {
-						log.Println(err)
-						continue
-					}
+				fileContents, err = whitespace.PreserveComments(existingFileContents, fileContents)
+				if err != nil {
+					log.Println(err)
+					continue
 				}
-				if preserveEmptyLines {
-					fileContents, err = whitespace.PreserveEmptyLines(existingFileContents, fileContents)
-					if err != nil {
-						log.Println(err)
-						continue
-					}
+				fileContents, err = whitespace.PreserveEmptyLines(existingFileContents, fileContents)
+				if err != nil {
+					log.Println(err)
+					continue
 				}
 			}
 
@@ -257,16 +273,10 @@ func init() {
 	fixCmd.PersistentFlags().BoolVar(&promptIfLineCountChange, "prompt-if-line-count-change", false, "show diff and prompt only if the number of lines changed. overrides '--prompt'.")
 	fixCmd.PersistentFlags().IntVar(&indentationLevel, "indentation-level", 2, "set yaml.v3 indentation spaces")
 	fixCmd.PersistentFlags().BoolVar(&compactLists, "compact-lists", true, "make '- ' count as part of the indentation for list items")
-	fixCmd.PersistentFlags().IntVar(&reduceIndentationBy, "reduce-list-indentation-by", 0, "deprecated: use --compact-lists instead")
-	_ = fixCmd.PersistentFlags().MarkDeprecated("reduce-list-indentation-by", "use --compact-lists instead")
 	fixCmd.PersistentFlags().BoolVar(&unmatchedToBeginning, "unmatched-to-beginning", false, "move keys not in the config to the beginning of their map instead of the end")
 	fixCmd.PersistentFlags().BoolVar(&addPreferreds, "add-preferred", false, "add lines marked as preferred when adding missing keys")
 	fixCmd.PersistentFlags().BoolVar(&validate, "validate", true, "use validation to determine if sorting should happen. (only sort if validation fails. this can prevent whitespace changes when unnecessary.)")
-	fixCmd.PersistentFlags().BoolVar(&preserveEmptyLines, "preserve-empty-lines", true, "preserve empty lines from the original file")
-	fixCmd.PersistentFlags().BoolVar(&preserveComments, "preserve-comments", true, "preserve spaces before comments from the original file")
-	fixCmd.PersistentFlags().BoolVarP(&disablePostProcessing, "disable-post-processing", "d", false, "disable preserve-empty-lines, preserve-comments, and compact-lists")
-	fixCmd.PersistentFlags().BoolVar(&disablePostProcessing, "disable-all-experiments", false, "deprecated: use --disable-post-processing")
-	_ = fixCmd.PersistentFlags().MarkDeprecated("disable-all-experiments", "use --disable-post-processing instead")
+	fixCmd.PersistentFlags().BoolVarP(&disablePostProcessing, "disable-post-processing", "d", false, "disable all post-processing (empty line preservation, comment preservation, compact lists)")
 }
 
 func generateDiff(filePath, oldContent, newContent string) string {

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -47,10 +47,6 @@ var lintCmd = &cobra.Command{
 	},
 	Run: func(cmd *cobra.Command, filePaths []string) {
 		// setup
-		configDirFlag := ""
-		if cfgDir != "" {
-			configDirFlag = cfgDir
-		}
 		workDir, err := os.Getwd()
 		if err != nil {
 			log.Fatal(err)
@@ -63,7 +59,9 @@ var lintCmd = &cobra.Command{
 		if err != nil {
 			log.Fatal(err)
 		}
-		cfgNodesByPaths := getConfigNodesByPath(configDirFlag, workDir, homeDir, allFilePaths)
+		projectCfg, projectCfgDir := loadProjectConfig(workDir, homeDir)
+		configDirFlag := resolveConfigDir(projectCfg, projectCfgDir)
+		cfgNodesByPaths := getConfigNodesByPath(configDirFlag, workDir, homeDir, allFilePaths, projectCfg, projectCfgDir)
 
 		success := true
 		for _, filePath := range allFilePaths {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,17 +33,23 @@ import (
 )
 
 const configDirName = ".predictable-yaml"
+const projectConfigFileName = ".predictable-yaml.yaml"
 
 var (
-	cfgDir        string
-	quiet         bool
-	yamlFileRegex = regexp.MustCompile(`(.*\.yaml$|.*\.yml$)`)
+	cfgDir         string
+	cfgFile        string
+	cfgFileChanged bool
+	quiet          bool
+	yamlFileRegex  = regexp.MustCompile(`(.*\.yaml$|.*\.yml$)`)
 )
 
 var rootCmd = &cobra.Command{
 	Use:   "predictable-yaml <command>",
 	Short: "Lint or fix YAML key order",
 	Long:  `Compare YAML files to config files.`,
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		cfgFileChanged = cmd.Flags().Changed("config-file")
+	},
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -56,6 +62,7 @@ func Execute() {
 
 func init() {
 	rootCmd.PersistentFlags().StringVar(&cfgDir, "config-dir", "", fmt.Sprintf("directory containing config file(s), (default is $HOME/%s)", configDirName))
+	rootCmd.PersistentFlags().StringVar(&cfgFile, "config-file", projectConfigFileName, "project config file path (searched up the directory tree unless explicitly set)")
 	if strings.HasPrefix(cfgDir, "~/") {
 		dirname, err := os.UserHomeDir()
 		if err != nil {
@@ -72,7 +79,7 @@ type configNodesByPath struct {
 }
 
 // getConfigNodesByPath reads files in configDirFlag or found config dir(s), populating []configNodesByPath
-func getConfigNodesByPath(configDirFlag, workDir, homeDir string, filePaths []string) []configNodesByPath {
+func getConfigNodesByPath(configDirFlag, workDir, homeDir string, filePaths []string, projectCfg *ProjectConfig, projectCfgDir string) []configNodesByPath {
 	var configDirs []string
 	if configDirFlag != "" {
 		configDirs = []string{configDirFlag}
@@ -91,14 +98,49 @@ func getConfigNodesByPath(configDirFlag, workDir, homeDir string, filePaths []st
 	// override more root configs with more specific configs
 	configNodes := compare.ConfigNodes{}
 
-	// First, load remote configs from parent config dirs (as base layer)
+	// First, try loading remote configs from project config file (.predictable-yaml.yaml)
 	hasRemoteConfig := false
-	for _, dir := range configDirs {
-		remoteNodes := loadRemoteConfigNodes(dir)
+	if projectCfg != nil && projectCfg.Remote.Version != "" {
+		remoteURL := projectCfg.Remote.URL
+		if remoteURL == "" {
+			remoteURL = remote.DefaultRemote
+		}
+		// Ensure .predictable-yaml directory exists for caching, relative to the project config file
+		cacheBaseDir := filepath.Join(projectCfgDir, configDirName)
+		if err := os.MkdirAll(cacheBaseDir, 0755); err != nil {
+			log.Fatalf("error creating config directory '%s': %v", cacheBaseDir, err)
+		}
+		cachePath, err := remote.FetchIfNeeded(remoteURL, projectCfg.Remote.Version, cacheBaseDir)
+		if err != nil {
+			log.Fatal(err)
+		}
+		checkGitignoreWarnings(cacheBaseDir)
+		remoteNodes := loadRemoteConfigNodesFromCache(cachePath)
 		if remoteNodes != nil {
 			hasRemoteConfig = true
 			for kind, node := range remoteNodes {
 				configNodes[kind] = node
+			}
+		}
+
+		// Warn if .predictable-yaml/.remote also exists
+		for _, dir := range configDirs {
+			remotePath := filepath.Join(dir, remote.RemoteFileName)
+			if _, err := os.Stat(remotePath); err == nil {
+				log.Printf("WARNING: '%s' is deprecated when using '%s'. Remove the .remote file and configure remote/version in %s instead.", remotePath, projectConfigFileName, projectConfigFileName)
+			}
+		}
+	}
+
+	// Fall back to .predictable-yaml/.remote files if no project config remote
+	if !hasRemoteConfig {
+		for _, dir := range configDirs {
+			remoteNodes := loadRemoteConfigNodes(dir)
+			if remoteNodes != nil {
+				hasRemoteConfig = true
+				for kind, node := range remoteNodes {
+					configNodes[kind] = node
+				}
 			}
 		}
 	}
@@ -200,7 +242,7 @@ func loadRemoteConfigNodes(configDir string) compare.ConfigNodes {
 		return nil
 	}
 
-	rc, err := remote.ParseRemoteConfig(remotePath)
+	legacyConfig, err := remote.ParseRemoteConfig(remotePath)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -208,11 +250,47 @@ func loadRemoteConfigNodes(configDir string) compare.ConfigNodes {
 	// Check gitignore warnings
 	checkGitignoreWarnings(configDir)
 
-	cachePath, err := remote.FetchIfNeeded(rc, configDir)
+	cachePath, err := remote.FetchIfNeeded(legacyConfig.Remote, legacyConfig.Version, configDir)
 	if err != nil {
 		log.Fatal(err)
 	}
 
+	configNodes := compare.ConfigNodes{}
+	configFiles, err := os.ReadDir(cachePath)
+	if err != nil {
+		log.Fatalf("error reading cached config dir '%s': %v", cachePath, err)
+	}
+	for _, file := range configFiles {
+		if file.IsDir() {
+			continue
+		}
+		if !yamlFileRegex.MatchString(file.Name()) {
+			continue
+		}
+		cNode := &yaml.Node{}
+		path := fmt.Sprintf("%s/%s", cachePath, file.Name())
+		_, err := getYAML(cNode, path)
+		if err != nil {
+			log.Fatalf("error parsing yaml for cached config file: %s: %v", path, err)
+		}
+		configNode := &compare.Node{Node: cNode}
+		compare.WalkConvertYamlNodeToMainNode(configNode)
+		compare.WalkParseLoadConfigComments(configNode)
+		if err := compare.WalkAndValidateConfig(configNode); err != nil {
+			log.Fatalf("error validating cached config file '%s': %v", path, err)
+		}
+		fileConfigs := compare.GetFileConfigs(configNode)
+		if fileConfigs.Kind == "" {
+			log.Fatalf("error determining schema for cached config file: %s: %v", path, err)
+		}
+		configNodes[fileConfigs.Kind] = configNode
+	}
+
+	return configNodes
+}
+
+// loadRemoteConfigNodesFromCache reads config nodes from an already-fetched cache directory.
+func loadRemoteConfigNodesFromCache(cachePath string) compare.ConfigNodes {
 	configNodes := compare.ConfigNodes{}
 	configFiles, err := os.ReadDir(cachePath)
 	if err != nil {
@@ -527,6 +605,9 @@ func getAllFilePaths(filePaths []string) ([]string, error) {
 			return filePaths, err
 		}
 		if !fileStat.IsDir() {
+			if filepath.Base(filePath) == projectConfigFileName {
+				continue
+			}
 			allFilePaths = append(allFilePaths, filePath)
 			continue
 		}
@@ -535,10 +616,14 @@ func getAllFilePaths(filePaths []string) ([]string, error) {
 				return err
 			}
 			if !info.IsDir() && yamlFileRegex.MatchString(info.Name()) {
-				// make sure we're not returning any config files
-				if !strings.Contains(p, configDirName) {
-					allFilePaths = append(allFilePaths, p)
+				// skip config directory files and project config file
+				if strings.Contains(p, configDirName) {
+					return nil
 				}
+				if info.Name() == projectConfigFileName {
+					return nil
+				}
+				allFilePaths = append(allFilePaths, p)
 			}
 			return nil
 		})
@@ -548,4 +633,108 @@ func getAllFilePaths(filePaths []string) ([]string, error) {
 	}
 
 	return allFilePaths, nil
+}
+
+// ProjectConfig represents the contents of a .predictable-yaml.yaml config file.
+type ProjectConfig struct {
+	ConfigDir string              `yaml:"config-dir"`
+	Remote    ProjectRemoteConfig `yaml:"remote"`
+	Fixer     ProjectFixerConfig  `yaml:"fixer"`
+}
+
+// ProjectRemoteConfig holds the remote config source settings.
+type ProjectRemoteConfig struct {
+	URL     string `yaml:"url"`
+	Version string `yaml:"version"`
+}
+
+// ProjectFixerConfig holds fixer default settings.
+type ProjectFixerConfig struct {
+	IndentationLevel        *int  `yaml:"indentation-level"`
+	CompactLists            *bool `yaml:"compact-lists"`
+	AddPreferred            *bool `yaml:"add-preferred"`
+	DisablePostProcessing   *bool `yaml:"disable-post-processing"`
+	Prompt                  *bool `yaml:"prompt"`
+	PromptIfLineCountChange *bool `yaml:"prompt-if-line-count-change"`
+	UnmatchedToBeginning    *bool `yaml:"unmatched-to-beginning"`
+	Validate                *bool `yaml:"validate"`
+}
+
+// resolveConfigDir returns the config directory, preferring CLI flag over project config.
+// Relative paths from the project config are resolved relative to the config file's directory.
+func resolveConfigDir(projectCfg *ProjectConfig, projectCfgDir string) string {
+	if cfgDir != "" {
+		return cfgDir
+	}
+	if projectCfg != nil && projectCfg.ConfigDir != "" {
+		if filepath.IsAbs(projectCfg.ConfigDir) {
+			return projectCfg.ConfigDir
+		}
+
+		return filepath.Join(projectCfgDir, projectCfg.ConfigDir)
+	}
+
+	return ""
+}
+
+// loadProjectConfig returns the project config and the directory it was found in.
+// If --config-file was explicitly set, the value is used as a direct path.
+// Otherwise, the default filename is searched up the directory tree.
+func loadProjectConfig(workDir, homeDir string) (*ProjectConfig, string) {
+	if cfgFileChanged {
+		cfg, err := parseProjectConfig(cfgFile)
+		if err != nil {
+			log.Fatal(err)
+		}
+		absPath, err := filepath.Abs(cfgFile)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		return cfg, filepath.Dir(absPath)
+	}
+	cfg, dir := findProjectConfig(cfgFile, workDir, homeDir)
+
+	return cfg, dir
+}
+
+// findProjectConfig searches up the directory tree from dir through homeDir for the named config file.
+// Returns the parsed config and the directory it was found in, or nil if not found.
+func findProjectConfig(fileName, dir, homeDir string) (*ProjectConfig, string) {
+	for {
+		configPath := filepath.Join(dir, fileName)
+		if _, err := os.Stat(configPath); err == nil {
+			cfg, err := parseProjectConfig(configPath)
+			if err != nil {
+				log.Fatalf("error parsing project config '%s': %v", configPath, err)
+			}
+
+			return cfg, dir
+		}
+		if dir == homeDir {
+			break
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+
+	return nil, ""
+}
+
+// parseProjectConfig reads and parses a .predictable-yaml.yaml file.
+func parseProjectConfig(path string) (*ProjectConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("error reading project config '%s': %w", path, err)
+	}
+
+	cfg := &ProjectConfig{}
+	if err := yaml.Unmarshal(data, cfg); err != nil {
+		return nil, fmt.Errorf("error parsing project config '%s': %w", path, err)
+	}
+
+	return cfg, nil
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"reflect"
 	"sort"
 	"testing"
@@ -145,7 +146,7 @@ TestCases:
 		}
 
 		// do it
-		got := getConfigNodesByPath(configDirFlag, fmtPath(tmpDir, tc.workDir), tmpDir, filePaths)
+		got := getConfigNodesByPath(configDirFlag, fmtPath(tmpDir, tc.workDir), tmpDir, filePaths, nil, "")
 		if !reflect.DeepEqual(got, expectedConfigNodesByPath) {
 			t.Errorf("Description: %s: cmd.getConfigNodesByPath(...): \n-expected:\n'%#v'\n+got:\n'%#v'\n", tc.note, expectedConfigNodesByPath, got)
 		}
@@ -367,6 +368,25 @@ func TestGetAllFilePaths(t *testing.T) {
 				"kustomize/overlays/fdsa/fdsa.yaml",
 			},
 		},
+		{
+			note: "excludes project config file from directory walk and direct path",
+			mkdirs: []string{
+				"my-project",
+			},
+			mkfiles: map[string][]byte{
+				"my-project/.predictable-yaml.yaml": []byte("version: v1.0.0\n"),
+				"my-project/deployment.yaml":        nil,
+				"my-project/service.yaml":           nil,
+			},
+			filePaths: []string{
+				"my-project",
+				"my-project/.predictable-yaml.yaml",
+			},
+			expectedFilePaths: []string{
+				"my-project/deployment.yaml",
+				"my-project/service.yaml",
+			},
+		},
 	}
 	for _, tc := range testCases {
 		// setup
@@ -388,6 +408,211 @@ func TestGetAllFilePaths(t *testing.T) {
 		if !reflect.DeepEqual(got, expectedFilePaths) {
 			t.Errorf("Description: %s: cmd.getAllFilePaths(...): \n-expected:\n'%#v'\n+got:\n'%#v'\n", tc.note, expectedFilePaths, got)
 		}
+	}
+}
+
+func TestFindProjectConfig(t *testing.T) {
+	type testCase struct {
+		note        string
+		mkdirs      []string
+		mkfiles     map[string][]byte
+		workDir     string
+		expectFound bool
+		expectDir   string // relative to tmpDir
+		checkFields func(*testing.T, *ProjectConfig)
+	}
+
+	testCases := []testCase{
+		{
+			note:   "finds config in working dir",
+			mkdirs: []string{"my-repo"},
+			mkfiles: map[string][]byte{
+				"my-repo/.predictable-yaml.yaml": []byte("remote:\n  version: v1.0.0\n"),
+			},
+			workDir:     "my-repo",
+			expectFound: true,
+			expectDir:   "my-repo",
+			checkFields: func(t *testing.T, cfg *ProjectConfig) {
+				if cfg.Remote.Version != "v1.0.0" {
+					t.Errorf("expected version v1.0.0, got %s", cfg.Remote.Version)
+				}
+			},
+		},
+		{
+			note:   "finds config in parent dir",
+			mkdirs: []string{"my-repo/subdir"},
+			mkfiles: map[string][]byte{
+				"my-repo/.predictable-yaml.yaml": []byte("remote:\n  url: https://example.com/repo\n  version: v2.0.0\n"),
+			},
+			workDir:     "my-repo/subdir",
+			expectFound: true,
+			expectDir:   "my-repo",
+			checkFields: func(t *testing.T, cfg *ProjectConfig) {
+				if cfg.Remote.Version != "v2.0.0" {
+					t.Errorf("expected version v2.0.0, got %s", cfg.Remote.Version)
+				}
+				if cfg.Remote.URL != "https://example.com/repo" {
+					t.Errorf("expected remote url https://example.com/repo, got %s", cfg.Remote.URL)
+				}
+			},
+		},
+		{
+			note:   "closest config wins",
+			mkdirs: []string{"my-repo/subdir"},
+			mkfiles: map[string][]byte{
+				".predictable-yaml.yaml":         []byte("remote:\n  version: v1.0.0\n"),
+				"my-repo/.predictable-yaml.yaml": []byte("remote:\n  version: v2.0.0\n"),
+			},
+			workDir:     "my-repo/subdir",
+			expectFound: true,
+			expectDir:   "my-repo",
+			checkFields: func(t *testing.T, cfg *ProjectConfig) {
+				if cfg.Remote.Version != "v2.0.0" {
+					t.Errorf("expected version v2.0.0 (closer config), got %s", cfg.Remote.Version)
+				}
+			},
+		},
+		{
+			note:        "no config found",
+			mkdirs:      []string{"my-repo"},
+			mkfiles:     map[string][]byte{},
+			workDir:     "my-repo",
+			expectFound: false,
+		},
+		{
+			note:   "finds config in home dir",
+			mkdirs: []string{"my-repo/subdir"},
+			mkfiles: map[string][]byte{
+				".predictable-yaml.yaml": []byte("remote:\n  version: v3.0.0\n"),
+			},
+			workDir:     "my-repo/subdir",
+			expectFound: true,
+			expectDir:   "",
+			checkFields: func(t *testing.T, cfg *ProjectConfig) {
+				if cfg.Remote.Version != "v3.0.0" {
+					t.Errorf("expected version v3.0.0, got %s", cfg.Remote.Version)
+				}
+			},
+		},
+		{
+			note:   "config with fixer settings",
+			mkdirs: []string{"my-repo"},
+			mkfiles: map[string][]byte{
+				"my-repo/.predictable-yaml.yaml": []byte("remote:\n  version: v1.0.0\nfixer:\n  indentation-level: 4\n  compact-lists: false\n"),
+			},
+			workDir:     "my-repo",
+			expectFound: true,
+			expectDir:   "my-repo",
+			checkFields: func(t *testing.T, cfg *ProjectConfig) {
+				if cfg.Fixer.IndentationLevel == nil || *cfg.Fixer.IndentationLevel != 4 {
+					t.Errorf("expected indentation-level 4, got %v", cfg.Fixer.IndentationLevel)
+				}
+				if cfg.Fixer.CompactLists == nil || *cfg.Fixer.CompactLists != false {
+					t.Errorf("expected compact-lists false, got %v", cfg.Fixer.CompactLists)
+				}
+			},
+		},
+		{
+			note:   "config without optional fields leaves them nil",
+			mkdirs: []string{"my-repo"},
+			mkfiles: map[string][]byte{
+				"my-repo/.predictable-yaml.yaml": []byte("remote:\n  version: v1.0.0\n"),
+			},
+			workDir:     "my-repo",
+			expectFound: true,
+			expectDir:   "my-repo",
+			checkFields: func(t *testing.T, cfg *ProjectConfig) {
+				if cfg.Fixer.IndentationLevel != nil {
+					t.Errorf("expected indentation-level nil, got %v", cfg.Fixer.IndentationLevel)
+				}
+				if cfg.Fixer.CompactLists != nil {
+					t.Errorf("expected compact-lists nil, got %v", cfg.Fixer.CompactLists)
+				}
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.note, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			err := setupFileSystem(tmpDir, tc.mkdirs, tc.mkfiles)
+			if err != nil {
+				t.Fatalf("setup error: %v", err)
+			}
+
+			cfg, foundDir := findProjectConfig(projectConfigFileName, fmtPath(tmpDir, tc.workDir), tmpDir)
+
+			if tc.expectFound {
+				if cfg == nil {
+					t.Fatalf("expected to find config, got nil")
+				}
+				expectedDir := fmtPath(tmpDir, tc.expectDir)
+				if foundDir != expectedDir {
+					t.Errorf("expected config dir %s, got %s", expectedDir, foundDir)
+				}
+				if tc.checkFields != nil {
+					tc.checkFields(t, cfg)
+				}
+			} else {
+				if cfg != nil {
+					t.Errorf("expected no config, got %+v", cfg)
+				}
+			}
+		})
+	}
+}
+
+func TestParseProjectConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Test valid config
+	validPath := filepath.Join(tmpDir, "valid.yaml")
+	if err := os.WriteFile(validPath, []byte("remote:\n  url: https://example.com/repo\n  version: v1.0.0\nfixer:\n  indentation-level: 4\n  compact-lists: false\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := parseProjectConfig(validPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Remote.URL != "https://example.com/repo" {
+		t.Errorf("expected remote url https://example.com/repo, got %s", cfg.Remote.URL)
+	}
+	if cfg.Remote.Version != "v1.0.0" {
+		t.Errorf("expected version v1.0.0, got %s", cfg.Remote.Version)
+	}
+	if cfg.Fixer.IndentationLevel == nil || *cfg.Fixer.IndentationLevel != 4 {
+		t.Errorf("expected indentation-level 4, got %v", cfg.Fixer.IndentationLevel)
+	}
+	if cfg.Fixer.CompactLists == nil || *cfg.Fixer.CompactLists != false {
+		t.Errorf("expected compact-lists false, got %v", cfg.Fixer.CompactLists)
+	}
+
+	// Test minimal config (version only)
+	minimalPath := filepath.Join(tmpDir, "minimal.yaml")
+	if err := os.WriteFile(minimalPath, []byte("remote:\n  version: v1.0.0\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err = parseProjectConfig(minimalPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Remote.URL != "" {
+		t.Errorf("expected empty remote url, got %s", cfg.Remote.URL)
+	}
+	if cfg.Remote.Version != "v1.0.0" {
+		t.Errorf("expected version v1.0.0, got %s", cfg.Remote.Version)
+	}
+	if cfg.Fixer.IndentationLevel != nil {
+		t.Errorf("expected nil indentation-level, got %v", cfg.Fixer.IndentationLevel)
+	}
+	if cfg.Fixer.CompactLists != nil {
+		t.Errorf("expected nil compact-lists, got %v", cfg.Fixer.CompactLists)
+	}
+
+	// Test nonexistent file
+	_, err = parseProjectConfig(filepath.Join(tmpDir, "nonexistent.yaml"))
+	if err == nil {
+		t.Error("expected error for nonexistent file")
 	}
 }
 

--- a/cmd/show_configs.go
+++ b/cmd/show_configs.go
@@ -71,13 +71,13 @@ var showConfigsCmd = &cobra.Command{
 			// Check for remote config
 			remotePath := filepath.Join(dir, remote.RemoteFileName)
 			if _, statErr := os.Stat(remotePath); statErr == nil {
-				rc, parseErr := remote.ParseRemoteConfig(remotePath)
+				legacyConfig, parseErr := remote.ParseRemoteConfig(remotePath)
 				if parseErr != nil {
 					fmt.Printf("  Remote config: ERROR: %v\n", parseErr)
 				} else {
 					hasRemoteConfig = true
-					fmt.Printf("  Remote: %s @ %s\n", rc.Remote, rc.Version)
-					cachePath, cacheErr := rc.CachePath(dir)
+					fmt.Printf("  Remote: %s @ %s\n", legacyConfig.Remote, legacyConfig.Version)
+					cachePath, cacheErr := remote.CachePath(legacyConfig.Remote, legacyConfig.Version, dir)
 					if cacheErr == nil {
 						if _, statErr := os.Stat(cachePath); statErr == nil {
 							fmt.Printf("  Cache: %s (cached)\n", cachePath)
@@ -107,9 +107,9 @@ var showConfigsCmd = &cobra.Command{
 
 				remotePath := filepath.Join(dir, remote.RemoteFileName)
 				if _, statErr := os.Stat(remotePath); statErr == nil {
-					rc, parseErr := remote.ParseRemoteConfig(remotePath)
+					legacyConfig, parseErr := remote.ParseRemoteConfig(remotePath)
 					if parseErr == nil {
-						fmt.Printf("  Remote: %s @ %s\n", rc.Remote, rc.Version)
+						fmt.Printf("  Remote: %s @ %s\n", legacyConfig.Remote, legacyConfig.Version)
 					}
 				}
 

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -36,54 +36,54 @@ const (
 	CacheDirName   = ".cache"
 )
 
-// RemoteConfig represents the contents of a .predictable-yaml/.remote file.
-type RemoteConfig struct {
+// LegacyRemoteConfig represents the contents of a .predictable-yaml/.remote file.
+type LegacyRemoteConfig struct {
 	Remote  string `yaml:"remote"`
 	Version string `yaml:"version"`
 }
 
 // ParseRemoteConfig reads and parses a .remote file.
-func ParseRemoteConfig(path string) (*RemoteConfig, error) {
+func ParseRemoteConfig(path string) (*LegacyRemoteConfig, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("error reading remote config '%s': %w", path, err)
 	}
 
-	rc := &RemoteConfig{}
-	if err := yaml.Unmarshal(data, rc); err != nil {
+	remoteConfig := &LegacyRemoteConfig{}
+	if err := yaml.Unmarshal(data, remoteConfig); err != nil {
 		return nil, fmt.Errorf("error parsing remote config '%s': %w", path, err)
 	}
 
-	if rc.Version == "" {
+	if remoteConfig.Version == "" {
 		return nil, fmt.Errorf("remote config '%s': 'version' is required (git tag, commit SHA, or branch name)", path)
 	}
 
-	if rc.Remote == "" {
-		rc.Remote = DefaultRemote
+	if remoteConfig.Remote == "" {
+		remoteConfig.Remote = DefaultRemote
 	}
 
-	return rc, nil
+	return remoteConfig, nil
 }
 
-// CachePath returns the local cache directory path for this remote config.
+// CachePath returns the local cache directory path for a remote URL and version.
 // Format: {configDir}/.cache/{host}/{owner}/{repo}/{ref}/
-func (rc *RemoteConfig) CachePath(configDir string) (string, error) {
-	parsed, err := url.Parse(rc.Remote)
+func CachePath(remoteURL, version, configDir string) (string, error) {
+	parsed, err := url.Parse(remoteURL)
 	if err != nil {
-		return "", fmt.Errorf("error parsing remote URL '%s': %w", rc.Remote, err)
+		return "", fmt.Errorf("error parsing remote URL '%s': %w", remoteURL, err)
 	}
 
 	// e.g. github.com/snarlysodboxer/predictable-yaml-configs/v2.3.0
 	repoPath := strings.TrimPrefix(parsed.Path, "/")
 	repoPath = strings.TrimSuffix(repoPath, ".git")
 
-	return filepath.Join(configDir, CacheDirName, parsed.Host, repoPath, rc.Version), nil
+	return filepath.Join(configDir, CacheDirName, parsed.Host, repoPath, version), nil
 }
 
 // FetchIfNeeded checks the cache and fetches remote configs if not already cached.
 // Returns the path to the cached config directory.
-func FetchIfNeeded(rc *RemoteConfig, configDir string) (string, error) {
-	cachePath, err := rc.CachePath(configDir)
+func FetchIfNeeded(remoteURL, version, configDir string) (string, error) {
+	cachePath, err := CachePath(remoteURL, version, configDir)
 	if err != nil {
 		return "", err
 	}
@@ -95,12 +95,12 @@ func FetchIfNeeded(rc *RemoteConfig, configDir string) (string, error) {
 	}
 
 	// Clean up any stale cache entries for other versions of the same remote
-	if err := cleanOldCacheEntries(rc, configDir); err != nil {
+	if err := cleanOldCacheEntries(remoteURL, version, configDir); err != nil {
 		return "", fmt.Errorf("error cleaning old cache entries: %w", err)
 	}
 
 	// Fetch configs
-	if err := fetchConfigs(rc, cachePath); err != nil {
+	if err := fetchConfigs(remoteURL, version, cachePath); err != nil {
 		return "", err
 	}
 
@@ -108,8 +108,8 @@ func FetchIfNeeded(rc *RemoteConfig, configDir string) (string, error) {
 }
 
 // cleanOldCacheEntries removes cached versions of the same remote repo that don't match the current ref.
-func cleanOldCacheEntries(rc *RemoteConfig, configDir string) error {
-	parsed, err := url.Parse(rc.Remote)
+func cleanOldCacheEntries(remoteURL, version, configDir string) error {
+	parsed, err := url.Parse(remoteURL)
 	if err != nil {
 		return err
 	}
@@ -127,7 +127,7 @@ func cleanOldCacheEntries(rc *RemoteConfig, configDir string) error {
 	}
 
 	for _, entry := range entries {
-		if entry.IsDir() && entry.Name() != rc.Version {
+		if entry.IsDir() && entry.Name() != version {
 			if err := os.RemoveAll(filepath.Join(repoDir, entry.Name())); err != nil {
 				return err
 			}
@@ -138,29 +138,29 @@ func cleanOldCacheEntries(rc *RemoteConfig, configDir string) error {
 }
 
 // fetchConfigs tries multiple strategies to download the remote configs.
-func fetchConfigs(rc *RemoteConfig, cachePath string) error {
+func fetchConfigs(remoteURL, version, cachePath string) error {
 	// Strategy 1: unauthenticated tarball download
-	err := fetchTarball(rc, cachePath, "")
+	err := fetchTarball(remoteURL, version, cachePath, "")
 	if err == nil {
 		return nil
 	}
 
 	// Strategy 2: authenticated tarball download using environment token
-	token := getAuthToken(rc.Remote)
+	token := getAuthToken(remoteURL)
 	if token != "" {
-		err = fetchTarball(rc, cachePath, token)
+		err = fetchTarball(remoteURL, version, cachePath, token)
 		if err == nil {
 			return nil
 		}
 	}
 
 	// Strategy 3: fall back to git commands
-	err = fetchViaGit(rc, cachePath)
+	err = fetchViaGit(remoteURL, version, cachePath)
 	if err == nil {
 		return nil
 	}
 
-	return fmt.Errorf("failed to fetch remote configs from '%s' at ref '%s': all fetch strategies failed", rc.Remote, rc.Version)
+	return fmt.Errorf("failed to fetch remote configs from '%s' at ref '%s': all fetch strategies failed", remoteURL, version)
 }
 
 // tarballURL constructs the tarball download URL based on the hosting provider.
@@ -192,8 +192,8 @@ func tarballURL(remoteURL, ref string) (string, error) {
 }
 
 // fetchTarball downloads and extracts a tarball of the remote configs.
-func fetchTarball(rc *RemoteConfig, cachePath, token string) error {
-	tbURL, err := tarballURL(rc.Remote, rc.Version)
+func fetchTarball(remoteURL, version, cachePath, token string) error {
+	tbURL, err := tarballURL(remoteURL, version)
 	if err != nil {
 		return err
 	}
@@ -310,7 +310,7 @@ func getAuthToken(remoteURL string) string {
 }
 
 // fetchViaGit uses git commands to fetch the remote configs as a fallback.
-func fetchViaGit(rc *RemoteConfig, cachePath string) error {
+func fetchViaGit(remoteURL, version, cachePath string) error {
 	if err := os.MkdirAll(cachePath, 0755); err != nil {
 		return fmt.Errorf("error creating cache directory '%s': %w", cachePath, err)
 	}
@@ -323,18 +323,18 @@ func fetchViaGit(rc *RemoteConfig, cachePath string) error {
 	defer os.RemoveAll(tmpDir)
 
 	// Try shallow clone with --branch first (works for tags and branches)
-	cmd := exec.Command("git", "clone", "--depth", "1", "--branch", rc.Version, rc.Remote, tmpDir)
+	cmd := exec.Command("git", "clone", "--depth", "1", "--branch", version, remoteURL, tmpDir)
 	if _, err := cmd.CombinedOutput(); err != nil {
 		// Fall back to full clone + checkout (needed for commit SHAs)
 		os.RemoveAll(tmpDir)
 		if err := os.MkdirAll(tmpDir, 0755); err != nil {
 			return fmt.Errorf("error recreating temp directory: %w", err)
 		}
-		cmd = exec.Command("git", "clone", rc.Remote, tmpDir)
+		cmd = exec.Command("git", "clone", remoteURL, tmpDir)
 		if output, err := cmd.CombinedOutput(); err != nil {
 			return fmt.Errorf("git clone failed: %s: %w", string(output), err)
 		}
-		cmd = exec.Command("git", "-C", tmpDir, "checkout", rc.Version)
+		cmd = exec.Command("git", "-C", tmpDir, "checkout", version)
 		if output, err := cmd.CombinedOutput(); err != nil {
 			return fmt.Errorf("git checkout failed: %s: %w", string(output), err)
 		}

--- a/pkg/remote/remote_test.go
+++ b/pkg/remote/remote_test.go
@@ -18,7 +18,7 @@ func TestParseRemoteConfig(t *testing.T) {
 	type testCase struct {
 		note        string
 		content     string
-		expected    *RemoteConfig
+		expected    *LegacyRemoteConfig
 		expectError bool
 	}
 
@@ -28,7 +28,7 @@ func TestParseRemoteConfig(t *testing.T) {
 			content: `
 version: v2.3.0
 `,
-			expected: &RemoteConfig{
+			expected: &LegacyRemoteConfig{
 				Remote:  DefaultRemote,
 				Version: "v2.3.0",
 			},
@@ -39,7 +39,7 @@ version: v2.3.0
 remote: https://github.com/my-org/my-configs
 version: v1.0.0
 `,
-			expected: &RemoteConfig{
+			expected: &LegacyRemoteConfig{
 				Remote:  "https://github.com/my-org/my-configs",
 				Version: "v1.0.0",
 			},
@@ -49,7 +49,7 @@ version: v1.0.0
 			content: `
 version: abc123def456
 `,
-			expected: &RemoteConfig{
+			expected: &LegacyRemoteConfig{
 				Remote:  DefaultRemote,
 				Version: "abc123def456",
 			},
@@ -60,7 +60,7 @@ version: abc123def456
 remote: https://gitlab.com/my-org/my-configs
 version: abc123def456
 `,
-			expected: &RemoteConfig{
+			expected: &LegacyRemoteConfig{
 				Remote:  "https://gitlab.com/my-org/my-configs",
 				Version: "abc123def456",
 			},
@@ -101,52 +101,45 @@ remote: https://github.com/my-org/my-configs
 func TestCachePath(t *testing.T) {
 	type testCase struct {
 		note      string
-		rc        *RemoteConfig
+		remoteURL string
+		version   string
 		configDir string
 		expected  string
 	}
 
 	testCases := []testCase{
 		{
-			note: "github with version",
-			rc: &RemoteConfig{
-				Remote:  "https://github.com/snarlysodboxer/predictable-yaml-configs",
-				Version: "v2.3.0",
-			},
+			note:      "github with version",
+			remoteURL: "https://github.com/snarlysodboxer/predictable-yaml-configs",
+			version:   "v2.3.0",
 			configDir: "/repo/.predictable-yaml",
 			expected:  "/repo/.predictable-yaml/.cache/github.com/snarlysodboxer/predictable-yaml-configs/v2.3.0",
 		},
 		{
-			note: "github with commit SHA as version",
-			rc: &RemoteConfig{
-				Remote:  "https://github.com/my-org/configs",
-				Version: "abc123def456",
-			},
+			note:      "github with commit SHA as version",
+			remoteURL: "https://github.com/my-org/configs",
+			version:   "abc123def456",
 			configDir: "/repo/.predictable-yaml",
 			expected:  "/repo/.predictable-yaml/.cache/github.com/my-org/configs/abc123def456",
 		},
 		{
-			note: "gitlab",
-			rc: &RemoteConfig{
-				Remote:  "https://gitlab.com/my-org/configs",
-				Version: "v1.0.0",
-			},
+			note:      "gitlab",
+			remoteURL: "https://gitlab.com/my-org/configs",
+			version:   "v1.0.0",
 			configDir: "/repo/.predictable-yaml",
 			expected:  "/repo/.predictable-yaml/.cache/gitlab.com/my-org/configs/v1.0.0",
 		},
 		{
-			note: "remote with .git suffix",
-			rc: &RemoteConfig{
-				Remote:  "https://github.com/my-org/configs.git",
-				Version: "v1.0.0",
-			},
+			note:      "remote with .git suffix",
+			remoteURL: "https://github.com/my-org/configs.git",
+			version:   "v1.0.0",
 			configDir: "/repo/.predictable-yaml",
 			expected:  "/repo/.predictable-yaml/.cache/github.com/my-org/configs/v1.0.0",
 		},
 	}
 
 	for _, tc := range testCases {
-		got, err := tc.rc.CachePath(tc.configDir)
+		got, err := CachePath(tc.remoteURL, tc.version, tc.configDir)
 		if err != nil {
 			t.Errorf("Description: %s: CachePath: unexpected error: %v", tc.note, err)
 			continue
@@ -278,13 +271,11 @@ func TestFetchIfNeeded(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rc := &RemoteConfig{
-		Remote:  fmt.Sprintf("%s/my-org/configs", server.URL),
-		Version: "v1.0.0",
-	}
+	remoteURL := fmt.Sprintf("%s/my-org/configs", server.URL)
+	version := "v1.0.0"
 
 	// First fetch — should download
-	cachePath, err := FetchIfNeeded(rc, configDir)
+	cachePath, err := FetchIfNeeded(remoteURL, version, configDir)
 	if err != nil {
 		t.Fatalf("FetchIfNeeded: unexpected error: %v", err)
 	}
@@ -301,7 +292,7 @@ func TestFetchIfNeeded(t *testing.T) {
 	}
 
 	// Second fetch — should use cache, no new request
-	cachePath2, err := FetchIfNeeded(rc, configDir)
+	cachePath2, err := FetchIfNeeded(remoteURL, version, configDir)
 	if err != nil {
 		t.Fatalf("FetchIfNeeded (cached): unexpected error: %v", err)
 	}
@@ -317,10 +308,8 @@ func TestCleanOldCacheEntries(t *testing.T) {
 	tmpDir := t.TempDir()
 	configDir := filepath.Join(tmpDir, ".predictable-yaml")
 
-	rc := &RemoteConfig{
-		Remote:  "https://github.com/my-org/configs",
-		Version: "v2.0.0",
-	}
+	remoteURL := "https://github.com/my-org/configs"
+	version := "v2.0.0"
 
 	// Create old cache entry
 	oldCachePath := filepath.Join(configDir, CacheDirName, "github.com", "my-org", "configs", "v1.0.0")
@@ -337,7 +326,7 @@ func TestCleanOldCacheEntries(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err := cleanOldCacheEntries(rc, configDir)
+	err := cleanOldCacheEntries(remoteURL, version, configDir)
 	if err != nil {
 		t.Fatalf("cleanOldCacheEntries: unexpected error: %v", err)
 	}
@@ -395,12 +384,10 @@ func TestFetchIfNeededNetworkError(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rc := &RemoteConfig{
-		Remote:  fmt.Sprintf("%s/my-org/configs", server.URL),
-		Version: "v1.0.0",
-	}
+	remoteURL := fmt.Sprintf("%s/my-org/configs", server.URL)
+	version := "v1.0.0"
 
-	_, err := FetchIfNeeded(rc, configDir)
+	_, err := FetchIfNeeded(remoteURL, version, configDir)
 	if err == nil {
 		t.Fatalf("FetchIfNeeded: expected error for failed fetch, got nil")
 	}


### PR DESCRIPTION
## Summary

- Introduce `.predictable-yaml.yaml` project config file that consolidates settings currently scattered across CLI flags and `.predictable-yaml/.remote`
- Simplify post-processing flags by removing `--preserve-empty-lines`, `--preserve-comments`, `--reduce-list-indentation-by`, and `--disable-all-experiments` - their behavior is now always-on unless `--disable-post-processing` is used.
- Deprecate `.predictable-yaml/.remote` in favor of the new config file (still honored for backward compatibility, with a deprecation warning when both exist.)

## Project Config File

A new `.predictable-yaml.yaml` file can be placed in a project root (or home directory) to set project-wide defaults:

```yaml
config-dir: .predictable-yaml

remote:
  url: https://github.com/my-org/my-yaml-configs
  version: v1.0.5

fixer:
  indentation-level: 2
  compact-lists: true
  add-preferred: false
  disable-post-processing: false
  prompt: true
  prompt-if-line-count-change: false
  unmatched-to-beginning: false
  validate: true
```

All fields are optional. CLI flags override config file values. The file is searched up the directory tree from the working directory through the home directory (closest wins).

### New CLI flags

- `--config-file` (default: `.predictable-yaml.yaml`) - override which project config file to use. When explicitly set, the path is used directly instead of searching up the directory tree.

### Removed CLI flags

- `--preserve-empty-lines` - behavior now always on (use `-d` to disable all post-processing)
- `--preserve-comments` - behavior now always on (use `-d` to disable all post-processing)
- `--reduce-list-indentation-by` - replaced by `--compact-lists` in the CompactSeqIndent PR
- `--disable-all-experiments` - replaced by `--disable-post-processing` / `-d`

## Files changed

- `pkg/remote/remote.go` - rename `RemoteConfig` to `LegacyRemoteConfig`, refactor `FetchIfNeeded`/`CachePath`/fetch functions to take `(remoteURL, version string)` instead of a struct, so both legacy and new config paths can call them cleanly
- `pkg/remote/remote_test.go` - updated to match new function signatures
- `cmd/root.go` - `ProjectConfig`/`ProjectRemoteConfig`/`ProjectFixerConfig` structs, `findProjectConfig()`, `loadProjectConfig()`, `resolveConfigDir()`, `loadRemoteConfigNodesFromCache()`, `--config-file` flag, updated `getConfigNodesByPath()` to use project config for remote fetching and `.remote` deprecation warnings, explicit exclusion of `.predictable-yaml.yaml` from file walks
- `cmd/fix.go` - removed old flag vars/registrations, apply all project config fields when CLI flags not explicitly set
- `cmd/lint.go` - pass project config through to `getConfigNodesByPath()`
- `cmd/show_configs.go` - updated to use new `remote.CachePath()` function signature and `LegacyRemoteConfig`
- `cmd/root_test.go` - `TestFindProjectConfig` (8 cases including home dir), `TestParseProjectConfig`, updated `TestGetAllFilePaths` with project config exclusion case
- `README.md` - new "Project Config File" section, "Legacy: `.predictable-yaml/.remote`" section, updated fixer features docs
