### PR TITLE
Fix fixer populating empty sequences/maps when parent key is not required

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ export PREDICTABLE_YAML_DIFF="difft"
 - **Preserve empty lines** - Associates empty lines with the YAML key following them and reinserts them after reordering. Reinserts trailing empty lines if present in the original.
 - **Preserve comments** - Replaces comment spacing with the original versions after reordering.
 - **Compact lists** - Makes `- ` count as part of the indentation for list items, so `-` is even with the parent key instead of indented. *(enabled by default, disable with `--compact-lists=false`)*
-- **Add missing keys** - Adds required keys that are missing from the file. Preferred keys can also be added with `--add-preferred`.
+- **Add missing keys** - Adds required keys that are missing from the file. Preferred keys can also be added with `--add-preferred`. Empty sequences (`[]`) and empty maps (`{}`) are only populated with required/preferred children when the parent key itself is required (or preferred with `--add-preferred`), so explicitly empty values are left alone.
 - **Unmatched key placement** - Keys in the file that aren't in the config are moved to the end of their map by default. Use `--unmatched-to-beginning` to move them to the start instead.
 - **Document marker** - Reinserts `---` at the beginning of the file if it was there before reordering.
 

--- a/flake.nix
+++ b/flake.nix
@@ -24,7 +24,7 @@
         };
         predictable-yaml = pkgs.buildGoModule {
           pname = "predictable-yaml";
-          version = "v1.0.0";
+          version = "v1.0.1";
           src = ./.;
           vendorHash = "sha256-mCFDgWqloouA8Taxss083D1sxhypg0/NTQNKLNuMH3U=";
           env.CGO_ENABLED = "0";

--- a/pkg/compare/compare.go
+++ b/pkg/compare/compare.go
@@ -329,7 +329,25 @@ func WalkAndSort(configNode, fileNode *Node, sortConfs SortConfigs, errs Validat
 			return append(errs, fmt.Errorf("program error: expected Sequence: '%s'", GetReferencePath(fileNode, 0, ""))), false
 		}
 		// use the same configNode for each entry in the sequence
-		if len(configNode.NodeContent) > 0 &&
+		// Only populate an empty sequence with required/preferred children
+		// if the parent key itself is required or preferred (with --add-preferred).
+		// This avoids adding entries to sequences the user intentionally left empty.
+		parentKeyIsRequired := false
+		parentKeyIsPreferred := false
+		if configNode.ParentNode != nil && configNode.ParentNode.Kind == yaml.MappingNode {
+			for i, n := range configNode.ParentNode.NodeContent {
+				if n.Kind == yaml.ScalarNode && i+1 < len(configNode.ParentNode.NodeContent) &&
+					configNode.ParentNode.NodeContent[i+1] == configNode {
+					parentKeyIsRequired = n.Required
+					parentKeyIsPreferred = n.Preferred
+					break
+				}
+			}
+		}
+		shouldPopulate := (parentKeyIsRequired && !sortConfs.FileConfigs.IgnoreRequireds) ||
+			(parentKeyIsPreferred && sortConfs.AddPreferreds && !sortConfs.FileConfigs.IgnoreRequireds)
+		if shouldPopulate &&
+			len(configNode.NodeContent) > 0 &&
 			configNode.NodeContent[0].Kind == yaml.MappingNode &&
 			len(fileNode.NodeContent) == 0 {
 			hasRequiredValue := false
@@ -352,7 +370,8 @@ func WalkAndSort(configNode, fileNode *Node, sortConfs SortConfigs, errs Validat
 				changed = true
 				errs, _ = WalkAndSort(configNode.NodeContent[0], fileNode.NodeContent[0], sortConfs, errs)
 			}
-		} else if len(configNode.NodeContent) > 0 &&
+		} else if shouldPopulate &&
+			len(configNode.NodeContent) > 0 &&
 			configNode.NodeContent[0].Kind == yaml.ScalarNode &&
 			len(fileNode.NodeContent) == 0 {
 			newYamlNode := &yaml.Node{

--- a/pkg/compare/compare_test.go
+++ b/pkg/compare/compare_test.go
@@ -1229,6 +1229,32 @@ spec:
           args: []
 `,
 		},
+		{
+			note:         "empty sequence not populated when parent key is not required",
+			toBeginning:  true,
+			expectedErrs: ValidationErrors{},
+			configYamls: []string{
+				`---
+apiVersion: gateway.networking.k8s.io/v1  # first, required
+kind: Gateway  # required
+spec:  # required
+  gatewayClassName: TODO  # first, required
+  listeners:
+  - name: TODO  # first, required
+    port: TODO  # required`},
+			fileYaml: `---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+spec:
+  gatewayClassName: envoy-ingress
+  listeners: []`,
+			expectedYaml: `apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+spec:
+  gatewayClassName: envoy-ingress
+  listeners: []
+`,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
- Fix fixer incorrectly populating empty sequences/maps with required children when the parent key is not itself required or preferred
- Previously, `listeners: []` would get `name: TODO` and `port: TODO` injected even though `listeners` is not a required key
- Now empty sequences and maps are only populated when the parent key is `# required` (or `# preferred` with `--add-preferred`)
- Gate preferred population on `AddPreferreds` and `IgnoreRequireds` to match the existing behavior in `sortNodes`
